### PR TITLE
Use correct field keys

### DIFF
--- a/core.go
+++ b/core.go
@@ -132,7 +132,7 @@ func (c *core) withLabels(fields []zapcore.Field) []zapcore.Field {
 func (c *core) withSourceLocation(ent zapcore.Entry, fields []zapcore.Field) []zapcore.Field {
 	// If the source location was manually set, don't overwrite it
 	for i := range fields {
-		if fields[i].Key == "sourceLocation" {
+		if fields[i].Key == sourceKey {
 			return fields
 		}
 	}

--- a/core_test.go
+++ b/core_test.go
@@ -54,19 +54,19 @@ func TestWithSourceLocation(t *testing.T) {
 
 	want := []zap.Field{
 		zap.String("hello", "world"),
-		zap.Object("sourceLocation", newSource(pc, file, line, ok)),
+		zap.Object(sourceKey, newSource(pc, file, line, ok)),
 	}
 
 	assert.Equal(t, want, (&core{}).withSourceLocation(ent, fields))
 }
 
 func TestWithSourceLocation_DoesNotOverwrite(t *testing.T) {
-	fields := []zap.Field{zap.String("sourceLocation", "world")}
+	fields := []zap.Field{zap.String(sourceKey, "world")}
 	pc, file, line, ok := runtime.Caller(0)
 	ent := zapcore.Entry{Caller: zapcore.NewEntryCaller(pc, file, line, ok)}
 
 	want := []zap.Field{
-		zap.String("sourceLocation", "world"),
+		zap.String(sourceKey, "world"),
 	}
 
 	assert.Equal(t, want, (&core{}).withSourceLocation(ent, fields))

--- a/operation.go
+++ b/operation.go
@@ -5,6 +5,8 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+const operationKey = "logging.googleapis.com/operation"
+
 // Operation adds the correct Stackdriver "operation" field.
 //
 // Additional information about a potentially long-running operation with which
@@ -19,7 +21,7 @@ func Operation(id, producer string, first, last bool) zap.Field {
 		Last:     last,
 	}
 
-	return zap.Object("operation", op)
+	return zap.Object(operationKey, op)
 }
 
 // operation is the complete payload that can be interpreted by Stackdriver as

--- a/operation_test.go
+++ b/operation_test.go
@@ -13,5 +13,5 @@ func TestOperation(t *testing.T) {
 	op := &operation{ID: "id", Producer: "producer", First: true, Last: false}
 	field := Operation("id", "producer", true, false)
 
-	assert.Equal(t, zap.Object("operation", op), field)
+	assert.Equal(t, zap.Object(operationKey, op), field)
 }

--- a/source.go
+++ b/source.go
@@ -8,11 +8,13 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+const sourceKey = "logging.googleapis.com/sourceLocation"
+
 // SourceLocation adds the correct Stackdriver "SourceLocation" field.
 //
 // see: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogEntrySourceLocation
 func SourceLocation(pc uintptr, file string, line int, ok bool) zap.Field {
-	return zap.Object("sourceLocation", newSource(pc, file, line, ok))
+	return zap.Object(sourceKey, newSource(pc, file, line, ok))
 }
 
 // source is the source code location information associated with the log entry,


### PR DESCRIPTION
* `sourceLocation` -> `logging.googleapis.com/sourceLocation`
* `operation` -> `logging.googleapis.com/operation`

See: https://cloud.google.com/logging/docs/agent/configuration#special_fields_in_structured_payloads