### PR TITLE
Add "operation" start/continue/end convenience functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,15 @@ logger.Debug("Progressing.", zapdriver.Operation("3g4d3g", "my-app", false, fals
 logger.Info("Done.", zapdriver.Operation("3g4d3g", "my-app", false, true))
 ```
 
+Instead of defining the "start" and "end" booleans, you can also use these three
+convenience functions:
+
+```golang
+OperationStart(id, producer string) zap.Field
+OperationCont(id, producer string) zap.Field
+OperationEnd(id, producer string) zap.Field
+```
+
 ### Pre-configured Stackdriver-optimized encoder
 
 The Stackdriver encoder maps all Zap log levels to the appropriate

--- a/operation.go
+++ b/operation.go
@@ -24,6 +24,24 @@ func Operation(id, producer string, first, last bool) zap.Field {
 	return zap.Object(operationKey, op)
 }
 
+// OperationStart is a convenience function for `Operation`. It should be called
+// for the first operation log.
+func OperationStart(id, producer string) zap.Field {
+	return Operation(id, producer, true, false)
+}
+
+// OperationCont is a convenience function for `Operation`. It should be called
+// for any non-start/end operation log.
+func OperationCont(id, producer string) zap.Field {
+	return Operation(id, producer, false, false)
+}
+
+// OperationEnd is a convenience function for `Operation`. It should be called
+// for the last operation log.
+func OperationEnd(id, producer string) zap.Field {
+	return Operation(id, producer, false, true)
+}
+
 // operation is the complete payload that can be interpreted by Stackdriver as
 // an operation.
 type operation struct {

--- a/operation_test.go
+++ b/operation_test.go
@@ -15,3 +15,30 @@ func TestOperation(t *testing.T) {
 
 	assert.Equal(t, zap.Object(operationKey, op), field)
 }
+
+func TestOperationStart(t *testing.T) {
+	t.Parallel()
+
+	op := &operation{ID: "id", Producer: "producer", First: true, Last: false}
+	field := OperationStart("id", "producer")
+
+	assert.Equal(t, zap.Object(operationKey, op), field)
+}
+
+func TestOperationCont(t *testing.T) {
+	t.Parallel()
+
+	op := &operation{ID: "id", Producer: "producer", First: false, Last: false}
+	field := OperationCont("id", "producer")
+
+	assert.Equal(t, zap.Object(operationKey, op), field)
+}
+
+func TestOperationEnd(t *testing.T) {
+	t.Parallel()
+
+	op := &operation{ID: "id", Producer: "producer", First: false, Last: true}
+	field := OperationEnd("id", "producer")
+
+	assert.Equal(t, zap.Object(operationKey, op), field)
+}


### PR DESCRIPTION
The following convenience functions are available:

```golang
OperationStart(id, producer string) zap.Field
OperationCont(id, producer string) zap.Field
OperationEnd(id, producer string) zap.Field
```