### PR TITLE
Use the correct format for the message timestamp

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -1,6 +1,10 @@
 package zapdriver
 
-import "go.uber.org/zap/zapcore"
+import (
+	"time"
+
+	"go.uber.org/zap/zapcore"
+)
 
 // logLevelSeverity maps the Zap log levels to the correct level names as
 // defined by Stackdriver.
@@ -37,7 +41,7 @@ var encoderConfig = zapcore.EncoderConfig{
 	StacktraceKey:  "stacktrace",
 	LineEnding:     zapcore.DefaultLineEnding,
 	EncodeLevel:    EncodeLevel,
-	EncodeTime:     zapcore.ISO8601TimeEncoder,
+	EncodeTime:     RFC3339NanoTimeEncoder,
 	EncodeDuration: zapcore.SecondsDurationEncoder,
 	EncodeCaller:   zapcore.ShortCallerEncoder,
 }
@@ -46,4 +50,10 @@ var encoderConfig = zapcore.EncoderConfig{
 // level.
 func EncodeLevel(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
 	enc.AppendString(logLevelSeverity[l])
+}
+
+// RFC3339NanoTimeEncoder serializes a time.Time to an RFC3339Nano-formatted
+// string with nanoseconds precision.
+func RFC3339NanoTimeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+	enc.AppendString(t.Format(time.RFC3339Nano))
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -2,6 +2,7 @@ package zapdriver_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/blendle/zapdriver"
 	"github.com/stretchr/testify/assert"
@@ -34,4 +35,16 @@ func TestEncodeLevel(t *testing.T) {
 			assert.Equal(t, enc.elems[0].(string), tt.want)
 		})
 	}
+}
+
+func TestRFC3339NanoTimeEncoder(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2018, 4, 9, 12, 43, 12, 678359, time.UTC)
+
+	enc := &sliceArrayEncoder{}
+	zapdriver.RFC3339NanoTimeEncoder(ts, enc)
+
+	require.Len(t, enc.elems, 1)
+	assert.Equal(t, ts.Format(time.RFC3339Nano), enc.elems[0].(string))
 }


### PR DESCRIPTION
As described in the Stackdriver documentation:

> A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds.
> Example: "2014-10-02T15:01:23.045123456Z".