### PR TITLE
Use correct timestamp key name

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -33,7 +33,7 @@ var logLevelSeverity = map[zapcore.Level]string{
 // encoderConfig is the default encoder configuration, slightly tweaked to use
 // the correct fields for Stackdriver to parse them.
 var encoderConfig = zapcore.EncoderConfig{
-	TimeKey:        "timestamp",
+	TimeKey:        "time",
 	LevelKey:       "severity",
 	NameKey:        "logger",
 	CallerKey:      "caller",


### PR DESCRIPTION
Continuation of https://github.com/blendle/zapdriver/pull/2, this time converting `timestamp` to `time`, as per [the documentation](https://cloud.google.com/logging/docs/agent/configuration#timestamp-processing).