### PR TITLE
Fix panic due to missing mutex lock/unlock

### DIFF
--- a/core.go
+++ b/core.go
@@ -82,7 +82,7 @@ func (c *core) Write(ent zapcore.Entry, fields []zapcore.Field) error {
 	fields = append(fields, labelsField(c.allLabels()))
 	fields = c.withSourceLocation(ent, fields)
 
-	c.tempLabels = newLabels()
+	c.tempLabels.reset()
 
 	return c.Core.Write(ent, fields)
 }

--- a/label.go
+++ b/label.go
@@ -58,6 +58,12 @@ func (l *labels) Add(key, value string) {
 	l.mutex.Unlock()
 }
 
+func (l *labels) reset() {
+	l.mutex.Lock()
+	l.store = map[string]string{}
+	l.mutex.Unlock()
+}
+
 func (l labels) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	l.mutex.RLock()
 	for k, v := range l.store {


### PR DESCRIPTION
We cannot just re-create the 'tempLabels' struct here without first
checking if the mutex is locked. The simplest solution is to have a
reset() function which resets the internal map, but preserves the
mutex state.