### PR TITLE
Adds support for attaching Error Reports to log entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ structured logging capabilities of Stackdriver:
 * [Special purpose logging fields](#special-purpose-logging-fields)
 * [Pre-configured Stackdriver-optimized encoder](#pre-configured-stackdriver-optimized-encoder)
 * [Custom Stackdriver Zap core](#custom-stackdriver-zap-core)
+* [Using Error Reporting](#using-error-reporting)
 
 The above components can be used separately, but to start, you can create a new
 Zap logger with all of the above included:
@@ -267,4 +268,64 @@ When building a logger, you can inject the Zapdriver core as follows:
 ```golang
 config := &zap.Config{}
 logger, err := config.Build(zapdriver.WrapCore())
+```
+
+### Using Error Reporting
+
+To report errors using StackDriver's Error Reporting tool, a log line needs to follow a separate log format described in the [Error Reporting][errorreporting] documentation.
+
+[errorreporting]: https://cloud.google.com/error-reporting/docs/formatting-error-messages
+
+The simplest way to do this is by using `NewProductionWithConfig`:
+
+```golang
+logger, err := zapdriver.NewProductionWithConfig(zapdriver.DriverConfig{
+  ReportAllErrors: true,
+  ServiceName: "my service",
+})
+```
+
+For parity-sake, there's also `zapdriver.NewDevelopmentWithConfig()`
+
+If you are building a custom logger, you can use `WrapCoreWithConfig()` instead to configure the driver core:
+
+```golang
+config := &zap.Config{}
+logger, err := config.Build(zapdriver.WrapCoreWithConfig(zapdriver.DriverConfig{
+  ReportAllErrors: true,
+  ServiceName: "my service",
+}))
+```
+
+Configuring this way, every error log entry will be reported to Stackdriver's Error Reporting tool.
+
+#### Reporting errors manually
+
+If you do not want every error to be reported, you can attach `ErrorReport()` to log call manually:
+
+```golang
+logger.Error("An error to be reported!", zapdriver.ErrorReport(runtime.Caller(0)))
+// Or get Caller details
+pc, file, line, ok := runtime.Caller(0)
+// do other stuff... and log elsewhere
+logger.Error("Another error to be reported!", zapdriver.ErrorReport(pc, file, line, ok))
+```
+
+Please keep in mind that ErrorReport needs a ServiceContext attached to the log
+entry. If you did not configure core using `DriverConfig`, error reports will
+get attached using service name as `unknown`. To prevent this from happeneing,
+either configure your core or attach service context before (or when) using
+the logger:
+
+```golang
+logger.Error(
+  "An error to be reported!",
+  zapdriver.ErrorReport(runtime.Caller(0)),
+  zapdriver.ServiceContext("my service"),
+)
+
+// Or permanently attach it to your logger
+logger = logger.With(zapdriver.ServiceContext("my service"))
+// and then use it
+logger.Error("An error to be reported!", zapdriver.ErrorReport(runtime.Caller(0)))
 ```

--- a/README.md
+++ b/README.md
@@ -276,25 +276,25 @@ To report errors using StackDriver's Error Reporting tool, a log line needs to f
 
 [errorreporting]: https://cloud.google.com/error-reporting/docs/formatting-error-messages
 
-The simplest way to do this is by using `NewProductionWithConfig`:
+The simplest way to do this is by using `NewProductionWithCore`:
 
 ```golang
-logger, err := zapdriver.NewProductionWithConfig(zapdriver.DriverConfig{
-  ReportAllErrors: true,
-  ServiceName: "my service",
-})
+logger, err := zapdriver.NewProductionWithCore(zapdriver.WrapCore(
+  zapdriver.ReportAllErrors(true),
+  zapdriver.ServiceName("my service"),
+))
 ```
 
-For parity-sake, there's also `zapdriver.NewDevelopmentWithConfig()`
+For parity-sake, there's also `zapdriver.NewDevelopmentWithCore()`
 
-If you are building a custom logger, you can use `WrapCoreWithConfig()` instead to configure the driver core:
+If you are building a custom logger, you can use `WrapCore()` to configure the driver core:
 
 ```golang
 config := &zap.Config{}
-logger, err := config.Build(zapdriver.WrapCoreWithConfig(zapdriver.DriverConfig{
-  ReportAllErrors: true,
-  ServiceName: "my service",
-}))
+logger, err := config.Build(zapdriver.WrapCore(
+  zapdriver.ReportAllErrors(true),
+  zapdriver.ServiceName("my service"),
+))
 ```
 
 Configuring this way, every error log entry will be reported to Stackdriver's Error Reporting tool.
@@ -312,7 +312,7 @@ logger.Error("Another error to be reported!", zapdriver.ErrorReport(pc, file, li
 ```
 
 Please keep in mind that ErrorReport needs a ServiceContext attached to the log
-entry. If you did not configure core using `DriverConfig`, error reports will
+entry. If you did not configure this using `WrapCore`, error reports will
 get attached using service name as `unknown`. To prevent this from happeneing,
 either configure your core or attach service context before (or when) using
 the logger:

--- a/core.go
+++ b/core.go
@@ -7,9 +7,14 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// DriverConfig is used to configure core. Use it with `WrapCoreWithConfig()`
 type DriverConfig struct {
+	// Report all logs with level error or above to stackdriver using
+	// `ErrorReport()` when set to true
 	ReportAllErrors bool
-	ServiceName     string
+
+	// ServiceName is added as `ServiceContext()` to all logs when set
+	ServiceName string
 }
 
 // Core is a zapdriver specific core wrapped around the default zap core. It
@@ -33,6 +38,7 @@ type core struct {
 	// Zap core.
 	tempLabels *labels
 
+	// Configuration for the zapdriver core
 	config DriverConfig
 }
 

--- a/core_test.go
+++ b/core_test.go
@@ -34,7 +34,11 @@ func TestWithLabels(t *testing.T) {
 
 func TestExtractLabels(t *testing.T) {
 	var lbls *labels
-	c := &core{zapcore.NewNopCore(), newLabels(), newLabels()}
+	c := &core{
+		Core:       zapcore.NewNopCore(),
+		permLabels: newLabels(),
+		tempLabels: newLabels(),
+	}
 
 	fields := []zap.Field{
 		zap.String("hello", "world"),
@@ -98,7 +102,11 @@ func TestWrite(t *testing.T) {
 	temp.store = map[string]string{"one": "1", "two": "2"}
 
 	debugcore, logs := observer.New(zapcore.DebugLevel)
-	core := &core{debugcore, newLabels(), temp}
+	core := &core{
+		Core:       debugcore,
+		permLabels: newLabels(),
+		tempLabels: temp,
+	}
 
 	fields := []zap.Field{
 		zap.String("hello", "world"),
@@ -119,7 +127,11 @@ func TestWriteConcurrent(t *testing.T) {
 	counter := int32(10000)
 
 	debugcore, logs := observer.New(zapcore.DebugLevel)
-	core := &core{debugcore, newLabels(), temp}
+	core := &core{
+		Core:       debugcore,
+		permLabels: newLabels(),
+		tempLabels: temp,
+	}
 
 	fields := []zap.Field{
 		zap.String("hello", "world"),
@@ -145,7 +157,11 @@ func TestWriteConcurrent(t *testing.T) {
 
 func TestWithAndWrite(t *testing.T) {
 	debugcore, logs := observer.New(zapcore.DebugLevel)
-	core := zapcore.Core(&core{debugcore, newLabels(), newLabels()})
+	core := zapcore.Core(&core{
+		Core:       debugcore,
+		permLabels: newLabels(),
+		tempLabels: newLabels(),
+	})
 
 	core = core.With([]zapcore.Field{Label("one", "world")})
 	err := core.Write(zapcore.Entry{}, []zapcore.Field{Label("two", "worlds")})
@@ -159,7 +175,11 @@ func TestWithAndWrite(t *testing.T) {
 
 func TestWithAndWrite_MultipleEntries(t *testing.T) {
 	debugcore, logs := observer.New(zapcore.DebugLevel)
-	core := zapcore.Core(&core{debugcore, newLabels(), newLabels()})
+	core := zapcore.Core(&core{
+		Core:       debugcore,
+		permLabels: newLabels(),
+		tempLabels: newLabels(),
+	})
 
 	core = core.With([]zapcore.Field{Label("one", "world")})
 	err := core.Write(zapcore.Entry{}, []zapcore.Field{Label("two", "worlds")})
@@ -188,7 +208,11 @@ func TestAllLabels(t *testing.T) {
 	temp := newLabels()
 	temp.store = map[string]string{"one": "ONE", "three": "THREE"}
 
-	core := &core{zapcore.NewNopCore(), perm, temp}
+	core := &core{
+		Core:       zapcore.NewNopCore(),
+		permLabels: perm,
+		tempLabels: temp,
+	}
 
 	out := core.allLabels()
 	require.Len(t, out.store, 3)

--- a/core_test.go
+++ b/core_test.go
@@ -267,7 +267,7 @@ func TestWriteReportAllErrors(t *testing.T) {
 		Core:       debugcore,
 		permLabels: newLabels(),
 		tempLabels: newLabels(),
-		config: DriverConfig{
+		config: driverConfig{
 			ReportAllErrors: true,
 		},
 	})
@@ -298,7 +298,7 @@ func TestWriteServiceContext(t *testing.T) {
 		Core:       debugcore,
 		permLabels: newLabels(),
 		tempLabels: newLabels(),
-		config: DriverConfig{
+		config: driverConfig{
 			ServiceName: "test service",
 		},
 	})
@@ -317,7 +317,7 @@ func TestWriteReportAllErrors_WithServiceContext(t *testing.T) {
 		Core:       debugcore,
 		permLabels: newLabels(),
 		tempLabels: newLabels(),
-		config: DriverConfig{
+		config: driverConfig{
 			ReportAllErrors: true,
 			ServiceName:     "test service",
 		},
@@ -343,7 +343,7 @@ func TestWriteReportAllErrors_InfoLog(t *testing.T) {
 		Core:       debugcore,
 		permLabels: newLabels(),
 		tempLabels: newLabels(),
-		config: DriverConfig{
+		config: driverConfig{
 			ReportAllErrors: true,
 		},
 	})

--- a/logger.go
+++ b/logger.go
@@ -14,12 +14,28 @@ func NewProduction(options ...zap.Option) (*zap.Logger, error) {
 	return NewProductionConfig().Build(options...)
 }
 
+// NewProductionWithConfig is same as NewProduction but accepts DriverConfig to
+// configure its core
+func NewProductionWithConfig(config DriverConfig, options ...zap.Option) (*zap.Logger, error) {
+	options = append(options, WrapCoreWithConfig(config))
+
+	return NewProductionConfig().Build(options...)
+}
+
 // NewDevelopment builds a development Logger that writes DebugLevel and above
 // logs to standard error in a human-friendly format.
 //
 // It's a shortcut for NewDevelopmentConfig().Build(...Option).
 func NewDevelopment(options ...zap.Option) (*zap.Logger, error) {
 	options = append(options, WrapCore())
+
+	return NewDevelopmentConfig().Build(options...)
+}
+
+// NewDevelopmentWithConfig is same as NewDevelopment but accepts DriverConfig to
+// configure its core
+func NewDevelopmentWithConfig(config DriverConfig, options ...zap.Option) (*zap.Logger, error) {
+	options = append(options, WrapCoreWithConfig(config))
 
 	return NewDevelopmentConfig().Build(options...)
 }

--- a/logger.go
+++ b/logger.go
@@ -14,10 +14,9 @@ func NewProduction(options ...zap.Option) (*zap.Logger, error) {
 	return NewProductionConfig().Build(options...)
 }
 
-// NewProductionWithConfig is same as NewProduction but accepts DriverConfig to
-// configure its core
-func NewProductionWithConfig(config DriverConfig, options ...zap.Option) (*zap.Logger, error) {
-	options = append(options, WrapCoreWithConfig(config))
+// NewProductionWithCore is same as NewProduction but accepts a custom configured core
+func NewProductionWithCore(core zap.Option, options ...zap.Option) (*zap.Logger, error) {
+	options = append(options, core)
 
 	return NewProductionConfig().Build(options...)
 }
@@ -32,10 +31,9 @@ func NewDevelopment(options ...zap.Option) (*zap.Logger, error) {
 	return NewDevelopmentConfig().Build(options...)
 }
 
-// NewDevelopmentWithConfig is same as NewDevelopment but accepts DriverConfig to
-// configure its core
-func NewDevelopmentWithConfig(config DriverConfig, options ...zap.Option) (*zap.Logger, error) {
-	options = append(options, WrapCoreWithConfig(config))
+// NewDevelopmentWithCore is same as NewDevelopment but accepts a custom configured core
+func NewDevelopmentWithCore(core zap.Option, options ...zap.Option) (*zap.Logger, error) {
+	options = append(options, core)
 
 	return NewDevelopmentConfig().Build(options...)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -16,11 +16,9 @@ func TestNewProduction(t *testing.T) {
 	assert.IsType(t, &zap.Logger{}, logger)
 }
 
-func TestNewProductionWithConfig(t *testing.T) {
-	logger, err := NewProductionWithConfig(
-		DriverConfig{
-			ReportAllErrors: true,
-		},
+func TestNewProductionWithCore(t *testing.T) {
+	logger, err := NewProductionWithCore(
+		WrapCore(ReportAllErrors(true)),
 		zap.Fields(zap.String("hello", "world")),
 	)
 
@@ -35,11 +33,9 @@ func TestNewDevelopment(t *testing.T) {
 	assert.IsType(t, &zap.Logger{}, logger)
 }
 
-func TestNewDevelopmentWithConfig(t *testing.T) {
-	logger, err := NewDevelopmentWithConfig(
-		DriverConfig{
-			ReportAllErrors: true,
-		},
+func TestNewDevelopmentWithCore(t *testing.T) {
+	logger, err := NewDevelopmentWithCore(
+		WrapCore(ReportAllErrors(true)),
 		zap.Fields(zap.String("hello", "world")),
 	)
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -16,8 +16,32 @@ func TestNewProduction(t *testing.T) {
 	assert.IsType(t, &zap.Logger{}, logger)
 }
 
+func TestNewProductionWithConfig(t *testing.T) {
+	logger, err := NewProductionWithConfig(
+		DriverConfig{
+			ReportAllErrors: true,
+		},
+		zap.Fields(zap.String("hello", "world")),
+	)
+
+	require.NoError(t, err)
+	assert.IsType(t, &zap.Logger{}, logger)
+}
+
 func TestNewDevelopment(t *testing.T) {
 	logger, err := NewDevelopment(zap.Fields(zap.String("hello", "world")))
+
+	require.NoError(t, err)
+	assert.IsType(t, &zap.Logger{}, logger)
+}
+
+func TestNewDevelopmentWithConfig(t *testing.T) {
+	logger, err := NewDevelopmentWithConfig(
+		DriverConfig{
+			ReportAllErrors: true,
+		},
+		zap.Fields(zap.String("hello", "world")),
+	)
 
 	require.NoError(t, err)
 	assert.IsType(t, &zap.Logger{}, logger)

--- a/report.go
+++ b/report.go
@@ -1,0 +1,62 @@
+package zapdriver
+
+import (
+	"runtime"
+	"strconv"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const contextKey = "context"
+
+func ErrorReport(pc uintptr, file string, line int, ok bool) zap.Field {
+	return zap.Object(contextKey, newReportContext(pc, file, line, ok))
+}
+
+type reportLocation struct {
+	File     string `json:"filePath"`
+	Line     string `json:"lineNumber"`
+	Function string `json:"functionName"`
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaller interface.
+func (location reportLocation) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("filePath", location.File)
+	enc.AddString("lineNumber", location.Line)
+	enc.AddString("functionName", location.Function)
+
+	return nil
+}
+
+type reportContext struct {
+	ReportLocation reportLocation `json:"reportLocation"`
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaller interface.
+func (context reportContext) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddObject("reportLocation", context.ReportLocation)
+
+	return nil
+}
+
+func newReportContext(pc uintptr, file string, line int, ok bool) *reportContext {
+	if !ok {
+		return nil
+	}
+
+	var function string
+	if fn := runtime.FuncForPC(pc); fn != nil {
+		function = fn.Name()
+	}
+
+	context := &reportContext{
+		ReportLocation: reportLocation{
+			File:     file,
+			Line:     strconv.Itoa(line),
+			Function: function,
+		},
+	}
+
+	return context
+}

--- a/report.go
+++ b/report.go
@@ -10,10 +10,17 @@ import (
 
 const contextKey = "context"
 
+// ErrorReport adds the correct Stackdriver "context" field for getting the log line
+// reported as error.
+//
+// see: https://cloud.google.com/error-reporting/docs/formatting-error-messages
 func ErrorReport(pc uintptr, file string, line int, ok bool) zap.Field {
 	return zap.Object(contextKey, newReportContext(pc, file, line, ok))
 }
 
+// reportLocation is the source code location information associated with the log entry
+// for the purpose of reporting an error,
+// if any.
 type reportLocation struct {
 	File     string `json:"filePath"`
 	Line     string `json:"lineNumber"`
@@ -29,6 +36,7 @@ func (location reportLocation) MarshalLogObject(enc zapcore.ObjectEncoder) error
 	return nil
 }
 
+// reportContext is the context information attached to a log for reporting errors
 type reportContext struct {
 	ReportLocation reportLocation `json:"reportLocation"`
 }

--- a/report_test.go
+++ b/report_test.go
@@ -1,0 +1,28 @@
+package zapdriver
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorReport(t *testing.T) {
+	t.Parallel()
+
+	got := ErrorReport(runtime.Caller(0)).Interface.(*reportContext)
+
+	assert.Contains(t, got.ReportLocation.File, "github.com/blendle/zapdriver/report_test.go")
+	assert.Equal(t, "13", got.ReportLocation.Line)
+	assert.Equal(t, "github.com/blendle/zapdriver.TestErrorReport", got.ReportLocation.Function)
+}
+
+func TestNewReportContext(t *testing.T) {
+	t.Parallel()
+
+	got := newReportContext(runtime.Caller(0))
+
+	assert.Contains(t, got.ReportLocation.File, "blendle/zapdriver/report_test.go")
+	assert.Equal(t, "23", got.ReportLocation.Line)
+	assert.Equal(t, "github.com/blendle/zapdriver.TestNewReportContext", got.ReportLocation.Function)
+}

--- a/service.go
+++ b/service.go
@@ -7,10 +7,17 @@ import (
 
 const serviceContextKey = "serviceContext"
 
+// ServiceContext adds the correct service information adding the log line
+// It is a required field if an error needs to be reported.
+//
+// see: https://cloud.google.com/error-reporting/reference/rest/v1beta1/ServiceContext
+// see: https://cloud.google.com/error-reporting/docs/formatting-error-messages
 func ServiceContext(name string) zap.Field {
 	return zap.Object(serviceContextKey, newServiceContext(name))
 }
 
+// serviceContext describes a running service that sends errors.
+// Currently it only describes a service name.
 type serviceContext struct {
 	Name string `json:"service"`
 }

--- a/service.go
+++ b/service.go
@@ -1,0 +1,29 @@
+package zapdriver
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const serviceContextKey = "serviceContext"
+
+func ServiceContext(name string) zap.Field {
+	return zap.Object(serviceContextKey, newServiceContext(name))
+}
+
+type serviceContext struct {
+	Name string `json:"service"`
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaller interface.
+func (service_context serviceContext) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("service", service_context.Name)
+
+	return nil
+}
+
+func newServiceContext(name string) *serviceContext {
+	return &serviceContext{
+		Name: name,
+	}
+}

--- a/service_test.go
+++ b/service_test.go
@@ -1,0 +1,23 @@
+package zapdriver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceContext(t *testing.T) {
+	t.Parallel()
+
+	got := ServiceContext("test service name").Interface.(*serviceContext)
+
+	assert.Equal(t, "test service name", got.Name)
+}
+
+func TestNewServiceContext(t *testing.T) {
+	t.Parallel()
+
+	got := newServiceContext("test service name")
+
+	assert.Equal(t, "test service name", got.Name)
+}


### PR DESCRIPTION
Fixes: #19 

Uses the the [Error Reporting format](https://cloud.google.com/error-reporting/docs/formatting-error-messages) to attach Error Reports to log entries.

zap field for an error report can be generated using `zapdriver.ErrorReport(runtime.Caller(0))`

Everything works out of the box by creating a logger using `zapdriver.NewProductionWithConfig`:

```golang
logger, err := zapdriver.NewProductionWithConfig(zapdriver.DriverConfig{
  ReportAllErrors: true,
  ServiceName: "my service",
})
```
This adds an error report to all error level log lines.

Also fixes: #18 
A wait group was added so that concurrent calls have time to finish running.