### PR TITLE
Change go version in go.mod: 1.12 -> 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/blendle/zapdriver
 
-go 1.12
+go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
Now, Go1.13 supports Go Modules as standard and [uber-go/zap](https://github.com/uber-go/zap) also supports Go1.13.
So, I hope this library supports it too.

Thanks for such a nice library!