### PR TITLE
Use console encoding for development config

### DIFF
--- a/config.go
+++ b/config.go
@@ -47,7 +47,7 @@ func NewDevelopmentConfig() zap.Config {
 	return zap.Config{
 		Level:            zap.NewAtomicLevelAt(zap.DebugLevel),
 		Development:      true,
-		Encoding:         "json",
+		Encoding:         "console",
 		EncoderConfig:    NewDevelopmentEncoderConfig(),
 		OutputPaths:      []string{"stderr"},
 		ErrorOutputPaths: []string{"stderr"},


### PR DESCRIPTION
As the comments suggest, use `console` encoding instead of `json` for a `NewDevelopment()` in order for them to be human readable. Perhaps this was missed but it makes sense for development not to care about JSON format for logs.

Either the comment saying `It enables development mode (which makes DPanicLevel logs panic), uses a console encoder,...` is wrong or it should be `console` instead of `json`