### PR TITLE
Better error stacktraces for Cloud Errors

### DIFF
--- a/core.go
+++ b/core.go
@@ -110,6 +110,12 @@ func (c *core) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.Check
 }
 
 func (c *core) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	for i, field := range fields {
+		if field.Type == zapcore.ErrorType {
+			FormatErrorField(&fields[i])
+		}
+	}
+
 	var lbls *labels
 	lbls, fields = c.extractLabels(fields)
 

--- a/error.go
+++ b/error.go
@@ -1,0 +1,37 @@
+package zapdriver
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap/zapcore"
+)
+
+func ErrFormat(err error) string {
+	if err == nil {
+		return ""
+	}
+	type stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+	cause := errors.Cause(err)
+	if stackTrace, ok := cause.(stackTracer); ok {
+		buf := bytes.Buffer{}
+		for i, frame := range stackTrace.StackTrace() {
+			if i == 0 {
+				buf.WriteByte('\n')
+			}
+
+			buf.WriteString(fmt.Sprintf("\n%+v", frame))
+		}
+		return err.Error() + buf.String()
+	}
+	return err.Error()
+}
+
+func FormatErrorField(field *zapcore.Field) {
+	if err, ok := field.Interface.(error); ok {
+		field.Interface = ErrFormat(err)
+	}
+}

--- a/error.go
+++ b/error.go
@@ -20,7 +20,11 @@ func (e stackdriverFmtError) Error() string {
 	if e.err == nil {
 		return ""
 	}
-	if stackTrace, ok := errors.Cause(e.err).(stackTracer); ok {
+	stackTrace, ok := errors.Cause(e.err).(stackTracer)
+	if !ok {
+		stackTrace, ok = e.err.(stackTracer)
+	}
+	if ok {
 		buf := bytes.NewBufferString(e.err.Error())
 		// routine id and state aren't available in pure go, so we hard-coded these
 		// required for stackdrivers runtime.Stack() format parsing

--- a/error_test.go
+++ b/error_test.go
@@ -1,10 +1,6 @@
 package zapdriver
 
 import (
-	"bytes"
-	"fmt"
-	"io"
-	"net/url"
 	"os"
 	"regexp"
 	"runtime"
@@ -13,19 +9,17 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 )
 
 type fakeErr struct{}
 
 // manually set the frames to allow asserting stacktraces
 func (fakeErr) StackTrace() errors.StackTrace {
-	var pcs = make([]uintptr, 2)
-	runtime.Callers(3, pcs)
-
+	pc1, _, _, _ := runtime.Caller(0)
+	pc2, _, _, _ := runtime.Caller(0)
 	return []errors.Frame{
-		errors.Frame(pcs[0]),
-		errors.Frame(pcs[1]),
+		errors.Frame(pc1),
+		errors.Frame(pc2),
 	}
 }
 func (fakeErr) Error() string {
@@ -37,58 +31,17 @@ func TestFmtStack(t *testing.T) {
 	assert.Equal(t, `fake error: underlying error
 
 goroutine 1 [running]:
-github.com/blendle/zapdriver.TestFmtStack()
-	/error_test.go:42 +0x1337
-testing.tRunner()
-	/testing.go:42 +0x1337`, makeStackTraceStable(stacktrace))
+github.com/blendle/zapdriver.fakeErr.StackTrace()
+	/error_test.go:18 +0x1337
+github.com/blendle/zapdriver.fakeErr.StackTrace()
+	/error_test.go:19 +0x1337`, makeStackTraceStable(stacktrace))
 }
 
-func ExampleUseFmtStackTracing() {
-	z, b := testZap()
-	z.Error("An error occurred", zap.Error(erroring()))
-
-	fmt.Println(makeStackTraceStable(b.String()))
-	// Output: {"severity":"ERROR","caller":"zapdriver/error_test.go:48","message":"An error occurred","exception":"bar: foo","logging.googleapis.com/labels":{},"logging.googleapis.com/sourceLocation":{"file":"/error_test.go","line":"48","function":"github.com/blendle/zapdriver.ExampleUseFmtStackTracing"}}
-}
-
-func testZap() (*zap.Logger, *bytes.Buffer) {
-	var b = bytes.NewBuffer(nil)
-	conf := NewDevelopmentConfig()
-	conf.EncoderConfig.TimeKey = ""
-	zap.RegisterSink("example", func(u *url.URL) (zap.Sink, error) { return testSink{b}, nil })
-	conf.OutputPaths = []string{"example://"} // to generate example output
-
-	z, err := conf.Build(WrapCore(
-		FmtStackTraces(true),
-		ReportAllErrors(false),
-	))
-
-	if err != nil {
-		panic(err)
-	}
-	return z, b
-}
-
-func erroring() error {
-	return errors.Wrap(fmt.Errorf("foo"), "bar")
-}
-
+// cleanup local paths & local function pointers
 func makeStackTraceStable(str string) string {
-	re := regexp.MustCompile(`(?m)^[\t\\t].+(\/\S+):\d+ \+0x.+$`)
-	str = re.ReplaceAllString(str, "\t${1}:42 +0x1337")
+	re := regexp.MustCompile(`(?m)^\t.+(\/\S+:\d+) \+0x.+$`)
+	str = re.ReplaceAllString(str, "\t${1} +0x1337")
 	dir, _ := os.Getwd()
 	str = strings.ReplaceAll(str, dir, "")
 	return str
-}
-
-type testSink struct {
-	io.Writer
-}
-
-func (testSink) Close() error {
-	return nil
-}
-
-func (testSink) Sync() error {
-	return nil
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,70 @@
+package zapdriver
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"runtime"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+type fakeErr struct{}
+
+// manually set the frames to allow asserting stacktraces
+func (fakeErr) StackTrace() errors.StackTrace {
+	var pcs = make([]uintptr, 2)
+	runtime.Callers(3, pcs)
+
+	return []errors.Frame{
+		errors.Frame(pcs[0]),
+		errors.Frame(pcs[1]),
+	}
+}
+func (fakeErr) Error() string {
+	return "fake error: underlying error"
+}
+
+func TestFmtStack(t *testing.T) {
+	stacktrace := stackdriverFmtError{fakeErr{}}.Error()
+	assert.Equal(t, `fake error: underlying error
+
+goroutine 1 [running]:
+github.com/blendle/zapdriver.TestFmtStack()
+	/error_test.go:42 +0x1337
+testing.tRunner()
+	/testing.go:42 +0x1337`, makeStackTraceStable(stacktrace))
+}
+
+func ExampleUseFmtStackTracing() {
+	zap.RegisterSink("example", func(u *url.URL) (zap.Sink, error) {
+		return os.Stdout, nil
+	})
+	conf := NewDevelopmentConfig()
+	conf.OutputPaths = []string{"stdout"} // to generate example output
+	z, err := conf.Build(WrapCore(
+		FmtStackTraces(true),
+		ReportAllErrors(true),
+		ServiceName("my-service"),
+	))
+
+	if err != nil {
+		panic(err)
+	}
+
+	z.Error("An error occurred", zap.Error(erroring()))
+	// Output: foo
+}
+
+func erroring() error {
+	return errors.Wrap(fmt.Errorf("foo"), "bar")
+}
+
+func makeStackTraceStable(str string) string {
+	re := regexp.MustCompile(`(?m)^\t.+(\/\S+):\d+ \+0x.+$`)
+	return re.ReplaceAllString(str, "\t${1}:42 +0x1337")
+}

--- a/error_test.go
+++ b/error_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 type fakeErr struct{}
@@ -44,4 +45,17 @@ func makeStackTraceStable(str string) string {
 	dir, _ := os.Getwd()
 	str = strings.ReplaceAll(str, dir, "")
 	return str
+}
+
+func ExampleSkipFmtStackTraces() {
+	logger, _ := NewProduction()
+	logger.Error("with exception", zap.Error(errors.New("internal error")), ErrorReport(runtime.Caller(0)))
+
+	logger, _ = NewProduction(WrapCore(ServiceName("service"), ReportAllErrors(true)))
+	logger.Error("with exception", zap.Error(errors.New("internal error")))
+
+	logger, _ = NewProduction(WrapCore(ServiceName("service"), SkipFmtStackTraces(true)))
+	logger.Error("without exception", zap.Error(errors.New("internal error")))
+
+	// Output:
 }


### PR DESCRIPTION
Anyone is free to use our fork as long as this is not merged. Use this in your go.mod:
```go
replace github.com/blendle/zapdriver => github.com/q42philips/zapdriver v1.3.2-pre.0
```

----

Stackdriver / GCP Cloud Errors is quite picky about the stacktraces it will parse. Specifically it does only parse the output of Go's `runtime.Stack()` which notably includes a `goroutine \d [running]:` part. Without those stack contents it does not parse.

This PR adapts zapdriver to include better stacktraces by default, when the error is reported to Cloud Errors (e.g. when the context and service name are set). It also uses the `exception` key instead of `stacktrace` because Cloud Error only contemplates the `message`, `stack_trace` and `exception` fields of the `jsonPayload`. The `stacktrace` key wasn't inspected at all, and even if it were, it contains the Zap formatted stack, which isn't compatible with Cloud Errors.

To view how this works, consider for example these different configurations:

```go
logger, _ := NewProduction()
logger.Error("with exception", zap.Error(errors.New("internal error")), ErrorReport(runtime.Caller(0)))

logger, _ = NewProduction(WrapCore(ServiceName("service"), ReportAllErrors(true)))
logger.Error("with exception", zap.Error(errors.New("internal error")))

logger, _ = NewProduction(WrapCore(ServiceName("service"), SkipFmtStackTraces(true)))
logger.Error("without exception", zap.Error(errors.New("internal error")))
```

The output would be as follows:

```
{"severity":"ERROR","timestamp":"2023-02-24T16:52:31.025432+01:00","caller":"zapdriver/error_test.go:52","message":"with exception","exception":"internal error\n\ngoroutine 1 [running]:\ngithub.com/blendle/zapdriver.ExampleSkipFmtStackTraces()\n\tgithub.com/blendle/zapdriver/error_test.go:52 +0x102264700\ntesting.runExample()\n\ttesting/run_example.go:63 +0x102176560\ntesting.runExamples()\n\ttesting/example.go:44 +0x102172b20\ntesting.(*M).Run()\n\ttesting/testing.go:1728 +0x10217b460\nmain.main()\n\t_testmain.go:131 +0x10226aa60\nruntime.main()\n\truntime/proc.go:250 +0x1020e8c20\nruntime.goexit()\n\truntime/asm_arm64.s:1172 +0x102118b40","context":{"reportLocation":{"filePath":"github.com/blendle/zapdriver/error_test.go","lineNumber":"52","functionName":"github.com/blendle/zapdriver.ExampleSkipFmtStackTraces"}},"logging.googleapis.com/labels":{},"logging.googleapis.com/sourceLocation":{"file":"github.com/blendle/zapdriver/error_test.go","line":"52","function":"github.com/blendle/zapdriver.ExampleSkipFmtSta
ckTraces"}}
{"severity":"ERROR","timestamp":"2023-02-24T16:52:31.025612+01:00","caller":"zapdriver/error_test.go:55","message":"with exception","exception":"internal error\n\ngoroutine 1 [running]:\ngithub.com/blendle/zapdriver.ExampleSkipFmtStackTraces()\n\tgithub.com/blendle/zapdriver/error_test.go:55 +0x102264700\ntesting.runExample()\n\ttesting/run_example.go:63 +0x102176560\ntesting.runExamples()\n\ttesting/example.go:44 +0x102172b20\ntesting.(*M).Run()\n\ttesting/testing.go:1728 +0x10217b460\nmain.main()\n\t_testmain.go:131 +0x10226aa60\nruntime.main()\n\truntime/proc.go:250 +0x1020e8c20\nruntime.goexit()\n\truntime/asm_arm64.s:1172 +0x102118b40","logging.googleapis.com/labels":{},"logging.googleapis.com/sourceLocation":{"file":"github.com/blendle/zapdriver/error_test.go","line":"55","function":"github.com/blendle/zapdriver.ExampleSkipFmtStackTraces"},"logging.googleapis.com/labels":{},"serviceContext":{"service":"service"},"context":{"reportLocation":{"filePath":"github.com/blendle/zapdriver/error_test.go","lineNu
mber":"55","functionName":"github.com/blendle/zapdriver.ExampleSkipFmtStackTraces"}}}
{"severity":"ERROR","timestamp":"2023-02-24T16:52:31.025644+01:00","caller":"zapdriver/error_test.go:58","message":"without exception","error":"internal error","errorVerbose":"internal error\ngithub.com/blendle/zapdriver.ExampleSkipFmtStackTraces\n\tgithub.com/blendle/zapdriver/error_test.go:58\ntesting.runExample\n\ttesting/run_example.go:63\ntesting.runExamples\n\ttesting/example.go:44\ntesting.(*M).Run\n\ttesting/testing.go:1728\nmain.main\n\t_testmain.go:131\nruntime.main\n\truntime/proc.go:250\nruntime.goexit\n\truntime/asm_arm64.s:1172","logging.googleapis.com/labels":{},"logging.googleapis.com/sourceLocation":{"file":"github.com/blendle/zapdriver/error_test.go","line":"58","function":"github.com/blendle/zapdriver.ExampleSkipFmtStackTraces"},"logging.googleapis.com/labels":{},"serviceContext":{"service":"service"},"stacktrace":"github.com/blendle/zapdriver.ExampleSkipFmtStackTraces\n\tgithub.com/blendle/zapdriver/error_test.go:58\ntesting.runExample\n\ttesting/run_example.go:63\ntesting.runExamples\n\tt
esting/example.go:44\ntesting.(*M).Run\n\ttesting/testing.go:1728\nmain.main\n\t_testmain.go:131\nruntime.main\n\truntime/proc.go:250"}
```

In Cloud Errors this would show as:

![Screenshot 2023-02-24 at 16 58 50](https://user-images.githubusercontent.com/791189/221226001-852f9716-fe31-4294-b77e-536031eca940.png)

Any **other** format (like Zap's stack format) would wrongly display as such:

![Screenshot 2023-02-24 at 16 59 57](https://user-images.githubusercontent.com/791189/221226273-61c6d563-d1ec-404c-a978-bff838f5855b.png)

The inspiration from this format comes from this error report:
https://github.com/googleapis/google-cloud-go/issues/1084#issuecomment-474565019
